### PR TITLE
[codex] 增加合并后版本发布触发

### DIFF
--- a/.github/workflows/build-exe.yml
+++ b/.github/workflows/build-exe.yml
@@ -3,6 +3,8 @@ name: Windows 可执行文件打包
 on:
   workflow_dispatch:
   push:
+    branches:
+      - main
     tags:
       - 'v*'
 
@@ -16,6 +18,22 @@ jobs:
     steps:
       - name: 检出代码
         uses: actions/checkout@v4
+
+      - name: 解析发布版本
+        id: release_version
+        shell: pwsh
+        run: |
+          if ("${{ github.ref }}" -like "refs/tags/*") {
+            $tag = "${{ github.ref_name }}"
+          } else {
+            $content = Get-Content -LiteralPath "todo_app/constants.py" -Raw
+            if ($content -notmatch 'APP_VERSION\s*=\s*"(?<version>\d+\.\d+\.\d+)"') {
+              throw "无法从 todo_app/constants.py 解析 APP_VERSION"
+            }
+            $tag = "v$($Matches.version)"
+          }
+          "release_tag=$tag" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          "RELEASE_TAG=$tag" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: 设置 Python
         uses: actions/setup-python@v5
@@ -59,8 +77,20 @@ jobs:
           path: dist/TODOList.exe
           if-no-files-found: error
 
+      - name: 同步发布标签
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        shell: pwsh
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -f $env:RELEASE_TAG $env:GITHUB_SHA
+          git push origin "refs/tags/$env:RELEASE_TAG" --force
+
       - name: 创建或更新发布
-        if: startsWith(github.ref, 'refs/tags/')
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ steps.release_version.outputs.release_tag }}
+          target_commitish: ${{ github.sha }}
           files: dist/TODOList.exe
+          overwrite_files: true

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@
 
 ## 打包与发布
 
-- 仓库提供的 GitHub Actions 工作流 `.github/workflows/build-exe.yml` 会在手动触发或推送 `v*` 标签时使用 PyInstaller 打包 Windows 平台的单文件可执行程序，构建结果会作为工作流附件保存；当以标签触发时还会自动更新 GitHub Release。
+- 仓库提供的 GitHub Actions 工作流 `.github/workflows/build-exe.yml` 会在手动触发、推送到 `main` 分支或推送 `v*` 标签时使用 PyInstaller 打包 Windows 平台的单文件可执行程序，构建结果会作为工作流附件保存；推送到 `main` 时会读取 `todo_app/constants.py` 中的 `APP_VERSION`，先同步对应 `v*` 标签到当前提交，再创建或更新该 Release，标签触发时则使用当前标签发布；手动触发仅用于打包验证，不会改动标签或 Release。
 - 若需本地验证，可执行：
   ```bash
   pyinstaller main.py --name TODOList --noconsole --clean -onefile --add-data "assets;assets" --hidden-import PySide6.QtSvg --hidden-import PySide6.QtMultimedia

--- a/anchor.md
+++ b/anchor.md
@@ -6,7 +6,7 @@
 ## 项目速览
 - **定位**：基于 PySide6 的桌面待办事项管理工具，强调现代化视觉、提醒/延迟机制与轻量本地存储。
 - **入口**：`main.py` 调用 `todo_app.run()`，由 `ModernTodoAppWindow`（`todo_app/main_window.py`）驱动 UI 与业务流。
-- **运行**：开发环境可执行 `python main.py`；GitHub Actions 工作流 `build-exe.yml` 负责生成 Windows 平台单文件可执行程序，并在推送 `v*` 标签时上传到 Release。
+- **运行**：开发环境可执行 `python main.py`；GitHub Actions 工作流 `build-exe.yml` 负责生成 Windows 平台单文件可执行程序，在推送到 `main` 分支时按 `APP_VERSION` 同步对应标签并创建或更新 Release，在推送 `v*` 标签时使用当前标签发布；手动触发仅上传构建产物。
 - **依赖要点**：PySide6 GUI 组件、`QSoundEffect` 播放提醒、`todos.json` 做本地数据缓存。
 
 ## 技术路径
@@ -68,6 +68,7 @@
 - 若确认无变更，提交说明需写明“锚点已复盘，无需更新”。
 
 ## 最近约定变更
+- 2026-06-21：refactor，Windows 打包工作流增加 main 分支 push 触发，合并后按 `APP_VERSION` 同步对应标签并创建或更新 Release，手动触发仅生成构建产物，标签触发 Release 的规则继续保留（不触发版本号）。
 - 2026-05-10：bugfix，抽离提醒调度规则，修复到期后推迟再编辑仍回显旧时间的问题，并让编辑保存按调度字段变化自动清理提醒状态，版本更新至 `v1.7.7`。
 - 2026-02-09：bugfix，优化提醒弹窗前置焦点流程避免列表抢焦点，并将“推迟”同步写回任务截止时间，版本更新至 `v1.7.6`。
 - 2026-01-11：bugfix，修正筛选/排序下拉框最长文本宽度计算逻辑，版本更新至 `v1.7.5`。


### PR DESCRIPTION
## 变更内容

- 将 `.github/workflows/build-exe.yml` 的 `push` 触发器扩展到 `main` 分支。
- `main` 分支 push 触发时读取 `todo_app/constants.py` 中的 `APP_VERSION`，生成 `vX.Y.Z` 作为 Release tag。
- 在更新 Release 前显式同步该 tag 到当前 `github.sha`，避免同一版本重复合并时 Release 资产更新但 tag 仍指向旧提交。
- 保留原有 `v*` 标签 push 触发逻辑，标签触发时使用当前标签发布。
- `workflow_dispatch` 手动触发仅用于打包验证和上传 artifact，不会同步 tag 或改动 Release。
- 同步更新 `README.md` 和 `anchor.md`，说明合并到 `main` 后会自动发布对应版本。

## 行为说明

PR 合并到 `main` 后会触发 Windows 打包 workflow，上传 `TODOList-windows` artifact，并用构建出的 `dist/TODOList.exe` 创建或更新当前 `APP_VERSION` 对应的 Release。当前版本未提升，因此按现有代码会发布到 `v1.7.7`；若 `v1.7.7` 已存在，workflow 会先把 tag 前移到当前提交再更新 Release。

## 验证

- `python -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('.github/workflows/build-exe.yml').read_text(encoding='utf-8')); print('YAML OK')"`
- `git diff --check`
- `python -m unittest discover -s tests`
- `python -m compileall todo_app tests`

锚点已复盘：本次触及 GitHub Actions 打包/发布流程，已在 `anchor.md` 最近约定变更登记；不触发应用版本号更新。
