### PR TITLE
修复：按应用版本生成预发布标签

### DIFF
--- a/.github/workflows/build-exe.yml
+++ b/.github/workflows/build-exe.yml
@@ -85,6 +85,15 @@ jobs:
           if ($LASTEXITCODE -ne 0 -or -not $remoteLine) {
             throw "无法读取远端 main 分支提交"
           }
+          $versionContent = Get-Content -LiteralPath "todo_app/constants.py" -Raw
+          if ($versionContent -notmatch 'APP_VERSION\s*=\s*"(?<version>\d+\.\d+\.\d+)"') {
+            throw "无法从 todo_app/constants.py 解析 APP_VERSION"
+          }
+          $appVersion = $Matches.version
+          $releaseTag = "pre$appVersion"
+          "app_version=$appVersion" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          "release_tag=$releaseTag" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
           $latestMainSha = ($remoteLine -split '\s+')[0]
           $shouldPublish = $latestMainSha -eq $env:GITHUB_SHA
           "should_publish=$($shouldPublish.ToString().ToLowerInvariant())" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
@@ -98,16 +107,17 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git tag -f pre-main $env:GITHUB_SHA
-          git push origin refs/tags/pre-main --force
+          $releaseTag = "${{ steps.main_preview.outputs.release_tag }}"
+          git tag -f $releaseTag $env:GITHUB_SHA
+          git push origin "refs/tags/$releaseTag" --force
 
       - name: 创建或更新主分支预发布
         if: steps.main_preview.outputs.should_publish == 'true'
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: pre-main
+          tag_name: ${{ steps.main_preview.outputs.release_tag }}
           target_commitish: ${{ github.sha }}
-          name: TODOList Main Preview
+          name: TODOList Preview ${{ steps.main_preview.outputs.app_version }}
           prerelease: true
           make_latest: false
           files: dist/TODOList.exe

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@
 ## 打包与发布
 
 - GitHub Actions 工作流 `.github/workflows/build-exe.yml` 会在手动触发、推送到 `main` 分支或推送 `v*` 标签时，使用 PyInstaller 打包 Windows 单文件可执行程序；所有构建都会上传名称含来源与短提交 SHA、保留 7 天的临时 Actions Artifact。
-- 推送到 `main` 时还会将专用可变标签 `pre-main` 更新到当前提交，并创建或更新标记为 Pre-release、不会成为 Latest Release 的 `TODOList Main Preview`，其中包含 `TODOList.exe`。只有该 `pre*` 预发布标签允许移动。
+- 推送到 `main` 时会读取 `todo_app/constants.py` 中的 `APP_VERSION`，将 `pre` 与版本号组合成预发布标签（例如 `1.7.14` 对应 `pre1.7.14`），并创建或更新不会成为 Latest Release 的 Pre-release，其中包含 `TODOList.exe`。同一版本号下，该 `pre<版本号>` 标签可随新的 `main` 提交更新。
 - 手动运行仅上传临时 Artifact，不创建或更新任何 Release，也不修改标签；即使手动选择标签 ref，仍保持临时构建语义。
 - 推送 `v*` 标签才会创建或更新对应的正式 Release，并上传 `TODOList.exe` 作为长期正式下载入口。所有 `v*` 版本标签均由发布者显式推送且保持不可变；同一标签的工作流重跑允许覆盖该标签的同名资产以恢复失败发布。
 - 若需本地验证，可执行：

--- a/anchor.md
+++ b/anchor.md
@@ -6,7 +6,7 @@
 ## 项目速览
 - **定位**：基于 PySide6 的桌面待办事项管理工具，强调现代化视觉、提醒/延迟机制与轻量本地存储。
 - **入口**：`main.py` 调用 `todo_app.run()`，由 `ModernTodoAppWindow`（`todo_app/main_window.py`）驱动 UI 与业务流。
-- **运行**：开发环境可执行 `python main.py`；GitHub Actions 工作流 `build-exe.yml` 在手动触发、推送到 `main` 或推送 `v*` 标签时生成 Windows 单文件可执行程序并上传保留 7 天的临时 Artifact。`main` 推送还会移动专用可变标签 `pre-main` 并更新不作为 Latest 的 Pre-release；手动构建不修改标签或 Release；只有显式推送且不可移动的 `v*` 标签才创建或更新正式 Release。
+- **运行**：开发环境可执行 `python main.py`；GitHub Actions 工作流 `build-exe.yml` 在手动触发、推送到 `main` 或推送 `v*` 标签时生成 Windows 单文件可执行程序并上传保留 7 天的临时 Artifact。`main` 推送还会根据 `APP_VERSION` 移动对应的 `pre<版本号>` 标签并更新不作为 Latest 的 Pre-release；手动构建不修改标签或 Release；只有显式推送且不可移动的 `v*` 标签才创建或更新正式 Release。
 - **依赖要点**：PySide6 GUI 组件、`QSoundEffect` 播放提醒、`todos.json` 做本地数据缓存。
 
 ## 技术路径
@@ -69,7 +69,7 @@
 - 若确认无变更，提交说明需写明“锚点已复盘，无需更新”。
 
 ## 最近约定变更
-- 2026-07-15：refactor，Windows 打包流程区分主分支 Pre-release、正式 Release 与临时 Artifact；`main` 更新专用可变标签 `pre-main` 及预发布，手动构建只上传保留 7 天的 Artifact，显式推送且不可移动的 `v*` 标签用于正式发布（不触发版本号）。
+- 2026-07-15：refactor，修正主分支预发布标签规则；`main` 根据 `APP_VERSION` 更新 `pre<版本号>` 标签（例如 `pre1.7.13`）及 Pre-release，手动构建只上传保留 7 天的 Artifact，显式推送且不可移动的 `v*` 标签用于正式发布（不触发版本号）。
 - 2026-07-13：bugfix，移除最小化及关闭到托盘时的系统气泡提示，保留静默托盘行为与软件内任务提醒，版本更新至 `v1.7.13`。
 - 2026-07-12：bugfix，多个任务的提醒改为单一非模态软件内汇总窗口，支持选择后批量完成或推迟并移除模态弹窗叠加，不增加系统任务通知，版本更新至 `v1.7.12`。
 - 2026-07-12：bugfix，新增任务默认截止时间统一为当前时间一小时后，移除凌晨改为 09:00 与日期固定为当天的分支，版本更新至 `v1.7.11`。


### PR DESCRIPTION
Refs #49

## 原行为

- 推送到 `main` 后固定移动 `pre-main` 标签。
- Pre-release 固定为 `TODOList Main Preview`，标签无法体现 `APP_VERSION`。

## 新行为

- `main` 构建从 `todo_app/constants.py` 解析 `APP_VERSION`。
- 将 `pre` 与版本号直接组合：当前 `1.7.13` 对应 `pre1.7.13`；未来 `1.7.14` 对应 `pre1.7.14`。
- 标签更新与 Pre-release 共用 `main_preview.release_tag` 输出，避免命名分叉。
- Pre-release 名称显示版本号，并继续设置 `prerelease: true`、`make_latest: false`。
- 保留远端 `main` 新鲜度守卫，旧任务不能回退当前版本的预发布。
- README 与 `anchor.md` 已同步。
- 不修改应用版本号或应用功能。

## 三种触发方式

| 触发方式 | Artifact | Release | 标签 |
| --- | --- | --- | --- |
| push `main` | 上传，保留 7 天 | 更新 `pre<APP_VERSION>` Pre-release | 仅允许移动当前 `pre<APP_VERSION>` |
| `workflow_dispatch` | 上传，保留 7 天 | 不发布 | 不修改 |
| push `v*` | 上传，保留 7 天 | 正式 Release | 不修改已推送的正式标签 |

## 标签边界

- 工作流不再引用或更新 `pre-main`。
- `v*` 正式标签仍由发布者显式推送且保持不可变。
- `pre<APP_VERSION>` 是版本化预发布标签；版本号不变时可随新 `main` 提交更新。
- 不增加 `pre*` push 触发，避免标签更新递归触发构建。
- 已存在的错误 `pre-main` 标签和 Release 暂不删除，需另行明确授权。

## 验证

- PyYAML BaseLoader 解析：通过。
- 触发器 `main` / `v*`：通过。
- `APP_VERSION` 解析、`pre` 前缀映射和输出复用断言：通过。
- `main` 新鲜度守卫断言：通过。
- 正式 `v*` Release 条件保持不变：通过。
- `retention-days: 7`：通过。
- 工作流、README、锚点中不存在 `pre-main`：通过。
- compare 仅包含工作流、README 和 `anchor.md`，共 24 行变动。
- 未在 PR 阶段执行 Windows PyInstaller；合入后的 `main` run 将验证 `pre1.7.13` 和 Release Asset。
