### PR TITLE
稳定主题切换测试的布局边界断言

### DIFF
--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -645,6 +645,21 @@ class TodoListCardIntegrationTest(unittest.TestCase):
                         combo,
                         palette.text_primary,
                     )
+                # grab() 会让 Qt 延迟刷新 sizeHint；重新稳定布局后再读取边界，
+                # 避免把上一主题的几何与当前主题的箭头位置混在一起。
+                self._settle_list_layout(window)
+                theme_control_bounds = [
+                    (
+                        control.mapTo(central_widget, QPoint(0, 0)).x(),
+                        control.mapTo(
+                            central_widget, QPoint(control.width(), 0)
+                        ).x(),
+                    )
+                    for control in controls
+                ]
+                for left, right in theme_control_bounds:
+                    self.assertGreaterEqual(left, controls_left)
+                    self.assertLessEqual(right, controls_right)
 
         option = QStyleOptionComboBox()
         option.initFrom(window.sort_combo)
@@ -742,7 +757,9 @@ class TodoListCardIntegrationTest(unittest.TestCase):
     @classmethod
     def _settle_list_layout(cls, window: ModernTodoAppWindow) -> None:
         cls.app.processEvents()
-        window.centralWidget().layout().activate()
+        central_layout = window.centralWidget().layout()
+        central_layout.invalidate()
+        central_layout.activate()
         window.list_widget.doItemsLayout()
         cls.app.processEvents()
 


### PR DESCRIPTION
## Summary

- 在浅色/深色主题的箭头像素抓取完成后，重新稳定 Qt 布局，并按当前主题重新读取筛选/排序控件边界。
- 将测试布局稳定器从单独 `activate()` 改为 `invalidate()` 后再 `activate()`，避免 Qt 仍把包含旧 sizeHint 的布局视为有效。
- 保留原有 320px 严格边界断言，不增加等待、不放宽尺寸、不修改生产代码。

Refs #68

## Verification

- 红灯复现：连续完整套件第 2 轮在深色主题稳定触发 `sort_combo right=333 > controls_right=305`，箭头右边界同时为 `331 > 305`。
- `D:\Develop\Tool\Miniconda\envs\try\python.exe -m unittest discover -s tests -v`：修复后连续执行 5 轮，每轮 48/48 通过。
- 相关测试：添加按钮深色图标 + 320px 筛选/排序主题切换，2/2 通过。
- `D:\Develop\Tool\Miniconda\envs\try\python.exe -m compileall todo_app`：通过。
- `git diff --check`：exit 0；仅有 Windows `LF will be replaced by CRLF` 工作区提示，无空白错误。

## Risk

- 风险仅限测试时序：`invalidate()` 会强制下一次 `activate()` 重新计算布局，使边界断言读取当前主题几何。
- 真实应用主题切换路径、样式、尺寸策略和业务行为均未改变。

## Non-goals

- 不修改 `ThemeManager`、主窗口主题实现或产品 UI。
- 不通过 sleep、重试或放宽 `320px` 边界掩盖失败。
- 不处理 #56、#55、#49 或冲突中的 PR #59。

## Follow-up

- 合并后关闭 #68；本 PR 保持未合并，等待 Codex 与人工检视。
- 锚点已复盘，无需更新；版本继续为 `v1.7.21`。
